### PR TITLE
Update Dockerfile for consistency to resolve the wrong performance comparison result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 ARG base=ubuntu:20.04
 
-FROM tensorchord/envd-sshd-from-scratch:v0.3.6 as sshd
+FROM tensorchord/envd-sshd-from-scratch:v0.3.11 as sshd
 FROM tensorchord/horust:v0.2.1 as horust
 
 FROM ${base}
 
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
-RUN apt-get update && \
+RUN apt-get update && apt-get install -y apt-utils && \
     apt-get install -y --no-install-recommends --fix-missing \
         bash-static \
         libtinfo5 \
@@ -30,7 +30,6 @@ RUN apt-get update && \
         vim \
         zsh \
         locales \
-    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://starship.rs/install.sh | sh -s -- -y && \
@@ -38,35 +37,36 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://starship.rs/install.sh | sh -s 
 
 ENV PATH /opt/conda/bin:$PATH
 
-ARG CONDA_VERSION=py310_22.11.1-1
+ARG CONDA_VERSION=py39_4.11.0
 
 RUN set -x && \
     UNAME_M="$(uname -m)" && \
     if [ "${UNAME_M}" = "x86_64" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
-        SHA256SUM="00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6"; \
+	    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
+	    SHA256SUM="4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"; \
     elif [ "${UNAME_M}" = "s390x" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
-        SHA256SUM="a150511e7fd19d07b770f278fb5dd2df4bc24a8f55f06d6274774f209a36c766"; \
+	    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
+	    SHA256SUM="e5e5e89cdcef9332fe632cd25d318cf71f681eef029a24495c713b18e66a8018"; \
     elif [ "${UNAME_M}" = "aarch64" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
-        SHA256SUM="48a96df9ff56f7421b6dd7f9f71d548023847ba918c3826059918c08326c2017"; \
+	    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
+	    SHA256SUM="00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556"; \
     elif [ "${UNAME_M}" = "ppc64le" ]; then \
-        MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh"; \
-        SHA256SUM="4c86c3383bb27b44f7059336c3a46c34922df42824577b93eadecefbf7423836"; \
+	    MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh"; \
+	    SHA256SUM="8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66"; \
     fi && \
     wget "${MINICONDA_URL}" -O miniconda.sh -q && \
     echo "${SHA256SUM} miniconda.sh" > shasum && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
-    mkdir -p /opt && \
-    bash miniconda.sh -b -p /opt/conda && \
-    rm miniconda.sh shasum && \
-    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    mkdir -p /opt/conda && \
+    sh miniconda.sh -b -u -p /opt/conda && \
+    touch ~/.bashrc && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
+    echo -e "channels:\n  - defaults" > /opt/conda/.condarc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy
+    /opt/conda/bin/conda clean -afy && \
+    rm miniconda.sh
 
 RUN conda create -n envd python=3.9
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,14 +59,14 @@ RUN set -x && \
     if [ "${CONDA_VERSION}" != "latest" ]; then sha256sum --check --status shasum; fi && \
     mkdir -p /opt/conda && \
     sh miniconda.sh -b -u -p /opt/conda && \
+    rm miniconda.sh shasum && \
     touch ~/.bashrc && \
     echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc && \
     echo -e "channels:\n  - defaults" > /opt/conda/.condarc && \
     find /opt/conda/ -follow -type f -name '*.a' -delete && \
     find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
-    /opt/conda/bin/conda clean -afy && \
-    rm miniconda.sh
+    /opt/conda/bin/conda clean -afy
 
 RUN conda create -n envd python=3.9
 


### PR DESCRIPTION
Signed-off-by: Botong Ou <richard97@g.ucla.edu>

Make Dockerfile consistent with the configuration of Envd. The changes include:
1. Use v0.3.11 envd-sshd which is used in Envd
2. Add `apt-get install -y apt-utils` as Envd also installed this [system.go](https://github.com/tensorchord/envd/blob/main/pkg/lang/ir/v1/system.go#:~:text=sb.WriteString(%22apt%2Dget%20update%20%26%26%20apt%2Dget%20install%20%2Dy%20apt%2Dutils%20%26%26%20%22))
3. Use the same version of conda as used in Envd and make the installation steps the same

Using this updated Dockerfile should give more accurate results for the performance comparison (Around *83s* for docker-cpu and *95s* for envd-v1 on my local machine).